### PR TITLE
?rankup: support spaces in usernames

### DIFF
--- a/src/events/message/commands/fun/rankup.ts
+++ b/src/events/message/commands/fun/rankup.ts
@@ -156,7 +156,7 @@ export default async function (message: Message, args: CommandArg[], opts: Optio
       message.reply(USAGE);
       return;
     }
-    [username] = result.data;
+    username = result.data.join(' ');
   }
 
   // If help option set, simply reply with usage info


### PR DESCRIPTION
Instead of just taking the first element of the `args` as username we can just join all elements with spaces to support usernames with spaces in `?rankup` command. Currently spaces have to be escaped with `%20` or the username has to be put in quotation marks.